### PR TITLE
Add configurable color jitter option to Visualizer class

### DIFF
--- a/src/deepdisc/astrodet/visualizer.py
+++ b/src/deepdisc/astrodet/visualizer.py
@@ -363,6 +363,9 @@ class Visualizer:
             metadata (Metadata): dataset metadata (e.g. class names and colors)
             instance_mode (ColorMode): defines one of the pre-defined style for drawing
                 instances on an image.
+            enable_color_jitter (bool): Whether to apply random color variations to instances
+            of the same class. Defaults to True. When False, uses exact colors from
+            metadata.thing_colors without modification.
         """
         self.img = np.asarray(img_rgb).clip(0, 255).astype(np.uint8)
         if metadata is None:

--- a/src/deepdisc/astrodet/visualizer.py
+++ b/src/deepdisc/astrodet/visualizer.py
@@ -352,7 +352,7 @@ class Visualizer:
 
     # TODO implement a fast, rasterized version using OpenCV
 
-    def __init__(self, img_rgb, metadata=None, scale=1.0, instance_mode=ColorMode.IMAGE):
+    def __init__(self, img_rgb, metadata=None, scale=1.0, instance_mode=ColorMode.IMAGE, enable_color_jitter=True):
         """
         Args:
             img_rgb: a numpy array of shape (H, W, C), where H and W correspond to
@@ -375,6 +375,9 @@ class Visualizer:
         self._default_font_size = max(np.sqrt(self.output.height * self.output.width) // 90, 10 // scale)
         self._instance_mode = instance_mode
         self.keypoint_threshold = _KEYPOINT_THRESHOLD
+        # Users can choose between segmentation-optimized colors (False) or instance distinction (True)
+        # default will be True as it preserves original behavior
+        self.enable_color_jitter = enable_color_jitter
 
     def draw_instance_predictions(self, predictions, alpha=0.5, lf=True, ls="-", boxf=False):
         """
@@ -1170,6 +1173,8 @@ class Visualizer:
             jittered_color (tuple[double]): a tuple of 3 elements, containing the RGB values of the
                 color after being jittered. The values in the list are in the [0.0, 1.0] range.
         """
+        if not self.enable_color_jitter:
+            return color  # return original color w/o modification
         color = mplc.to_rgb(color)
         vec = np.random.rand(3)
         # better to do it in another color space


### PR DESCRIPTION
We now have a `enable_color_jitter` parameter to the Visualizer class, allowing users to disable random color variations while maintaining backward compatibility.

**Key Changes**:
- Added `enable_color_jitter` boolean parameter to `Visualizer.__init__` while preserving default jittering behavior (`True`)
- Modified `_jitter` method to follow the new flag
- Updated docs with `Visualizer` class

Here's some example usage:
```python
from deepdisc.data_format.register_data import register_data_set
from deepdisc.astrodet.visualizer import Visualizer

custom_colors = [
    (0, 255, 0),    # green for galaxies
    (0, 0, 255),    # blue for stars
]
test_md= register_data_set('test', test_data_file, 
               thing_classes=["galaxy", "star"]).set(thing_colors=custom_colors)
v = Visualizer(
    img,
    metadata=test_md,
	scale=1,
    instance_mode=ColorMode.SEGMENTATION,
    enable_color_jitter=False  # Disable color variations
)
```

This fixes inconsistent annotation colors when using custom metadata colors.