### PR TITLE
Fix undefined logger causing runtime error in conversions.py

### DIFF
--- a/src/deepdisc/data_format/conversions.py
+++ b/src/deepdisc/data_format/conversions.py
@@ -7,6 +7,8 @@ import scarlet
 from detectron2.utils.file_io import PathManager
 from iopath.common.file_io import file_lock
 import os, json, shutil
+import logging
+logger = logging.getLogger(__name__)
 
 def fitsim_to_numpy(img_files, outdir):
     """Converts a list of single-band FITS images to multi-band numpy arrays


### PR DESCRIPTION
This fixes a simple runtime error in `src/deepdisc/data_format/conversions.py` where the function `convert_to_json` uses `logger.warning(...)` without defining or importing a logger.

Previously, calling `convert_to_json` with `allow_cached=True` and an existing file would result in:
```
NameError: name 'logger' is not defined
```
because the `logger` object was never set up in the file.

So, now with the `logging` import and defined `logger` at the top of the file, this ensures that all the logging calls are now valid and prevents the runtime crash.