### PR TITLE
Changed return_test_loader to work on unlabeled data with no annotations

### DIFF
--- a/src/deepdisc/model/loaders.py
+++ b/src/deepdisc/model/loaders.py
@@ -142,7 +142,8 @@ def return_test_loader(cfg, mapper):
     """
     batch_size = getattr(cfg.dataloader.test, 'total_batch_size', 1)
     num_workers = getattr(cfg.dataloader.test, 'num_workers', 0)
-    dataset = get_detection_dataset_dicts(cfg.DATASETS.TEST)
+    # Set filter_empty=False to allow images without annotations (for inference on unlabeled data)
+    dataset = get_detection_dataset_dicts(cfg.DATASETS.TEST, filter_empty=False)
     # loader w/ explicit params so we can bypass @configurable for detectron2's build_detection_test_loader()
     loader = data.build_detection_test_loader(
         dataset,


### PR DESCRIPTION
This pull request updates the test data loader to better support inference on unlabeled data. The change ensures that images without annotations are included during test time, which is important for scenarios such as evaluating on new or unlabeled datasets like the Legacy Survey of Space and Time's Data Preview 1 data. 

Test data loader behavior:

* Modified the call to `get_detection_dataset_dicts` in `return_test_loader` (in `loaders.py`) to set `filter_empty=False`, allowing images without annotations to be included in the test dataset